### PR TITLE
Fixed path for the sampler target

### DIFF
--- a/src/makefile
+++ b/src/makefile
@@ -82,7 +82,7 @@ slc_2d: partitionalgo/slc/slc_2d.cpp
 str_2d: partitionalgo/str/str_2d.cpp
 	$(CXX) -std=c++0x $< $(INCFLAGS) $(LIBS) $(OPTFLAGS) -o ${builddir}/$@
 
-sampler: partitioner/sampler.cpp
+sampler: transform/sampler.cpp
 	$(CXX) -std=c++0x $< $(INCFLAGS) $(OPTFLAGS) -o ${builddir}/$@
 
 partition_vis: visualizer/partition_vis.cpp


### PR DESCRIPTION
The makefile contains a wrong path for the target 'sampler'. Therefore, the 'sampler' binary couldn't be built. This patch fixes the issue.